### PR TITLE
Implemented CV_CAP_PROP_AUTO_EXPOSURE on cap_dshow

### DIFF
--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -3476,6 +3476,18 @@ bool VideoCapture_DShow::setProperty(int propIdx, double propVal)
         return g_VI.isDeviceSetup(m_index);
     }
 
+    case CV_CAP_PROP_AUTO_EXPOSURE:
+    {
+        // Flags are required to toggle auto exposure or not, but the setProperty interface does not support multiple parameters
+        bool enabled = cvRound(propVal) == 1;
+        long minExposure, maxExposure, delta, currentExposure, flags, defaultValue;
+        if (!g_VI.getVideoSettingCamera(m_index, CameraControl_Exposure, minExposure, maxExposure, delta, currentExposure, flags, defaultValue))
+        {
+            return false;
+        }
+        return g_VI.setVideoSettingCamera(m_index, CameraControl_Exposure, currentExposure, enabled ? CameraControl_Flags_Auto | CameraControl_Flags_Manual : CameraControl_Flags_Manual, enabled ? true : false);
+    }
+
     case CV_CAP_PROP_AUTOFOCUS:
     {
         // Flags are required to toggle autofocus or not, but the setProperty interface does not support multiple parameters


### PR DESCRIPTION
Setting CAP_PROP_AUTO_EXPOSURE on VideoCapture with backend DSHOW does not change anything. Now with this implementation the property can be used with value 1 for availability.

https://github.com/opencv/opencv/issues/17019
https://github.com/opencv/opencv/issues/15958
https://github.com/opencv/opencv/issues/14494
https://github.com/opencv/opencv/issues/9738

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
